### PR TITLE
Extend Redix config to support all start_link/1 options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,15 @@ in your config to:
 ```elixir
 config :guardian, Guardian.DB, adapter: GuardianRedis.Adapter
 ```
+
+### Added
+- support for all configuration options of Redix (except for name)
+- support for `name_prefix` config
+
 ### Breaking
 - bump `GuardianDB` from 2.1.1 to 3.0.0
+- `port` and `pool_size` config options have to be integers now
+- default Redix connection name prefix changed from `redix` to `guardian_redis`. Previous name can be preserved by adding `name_prefix: "redix"` to the config
 
 ## V0.1.0
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ config :guardian_redis, :redis,
   pool_size: 10
 ```
 
+More options are available as described in `GuardianRedis.Redix`.
+
 
 ## Implement Guardian.DB adapter for a different storage
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -4,5 +4,5 @@ config :guardian, Guardian.DB, adapter: GuardianRedis.Adapter
 
 config :guardian_redis, :redis,
   host: System.get_env("REDIS_HOST", "127.0.0.1"),
-  port: System.get_env("REDIS_PORT", "6379"),
-  pool_size: System.get_env("REDIS_POOL_SIZE", "1")
+  port: String.to_integer(System.get_env("REDIS_PORT", "6379")),
+  pool_size: String.to_integer(System.get_env("REDIS_POOL_SIZE", "1"))


### PR DESCRIPTION
I wanted to use this lib, but there was no way to pass the `password` config to Redix, nor other potentially desired options for that matter... So here is a PR for that :)

### Added
- support for all configuration options of Redix (except for name)
- support for `name_prefix` config

### Breaking
- `port` and `pool_size` config options have to be integers now

Don't mind all the force-pushes... :D